### PR TITLE
Matches Optimization

### DIFF
--- a/src/main/java/com/example/SS2_Backend/ss/smt/Matches.java
+++ b/src/main/java/com/example/SS2_Backend/ss/smt/Matches.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.experimental.FieldDefaults;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -23,9 +24,6 @@ public class Matches implements Serializable {
     /** matches data */
     final TreeSet<Integer>[] matches;
 
-    /** leftover individuals go here =)) */
-    final TreeSet<Integer> leftOvers = (new TreeSet<>());
-
     @SuppressWarnings("unchecked")
     public Matches(int size) {
         this.size = size;
@@ -43,15 +41,6 @@ public class Matches implements Serializable {
      */
     public Set<Integer> getSetOf(int targetIndividual) {
         return matches[targetIndividual];
-    }
-
-    /**
-     * add node to leftOvers :((
-     *
-     * @param leftOverNode int
-     */
-    public void addLeftOver(int leftOverNode) {
-        leftOvers.add(leftOverNode);
     }
 
     /**
@@ -152,8 +141,20 @@ public class Matches implements Serializable {
             i++;
         }
 
-        sb.append("Left Overs: ").append(leftOvers).append("\n");
+        sb.append("Left Overs: ").append(getLeftOvers()).append("\n");
         return sb;
+    }
+
+    public Set<Integer> getLeftOvers() {
+        ArrayList<Integer> leftOvers = new ArrayList<>();
+
+        for (int i = 0; i < matches.length; i++) {
+             if ( matches[i].isEmpty()) {
+                leftOvers.add(i);
+             }
+        }
+
+        return new TreeSet(leftOvers);
     }
 
     /**

--- a/src/main/java/com/example/SS2_Backend/ss/smt/implement/MTMProblem.java
+++ b/src/main/java/com/example/SS2_Backend/ss/smt/implement/MTMProblem.java
@@ -164,7 +164,6 @@ public class MTMProblem implements MatchingProblem {
 
                     if (loser == newNode) {
                         if (preferenceLists.getLastChoiceOf(UNUSED_VAL, newNode) == preferNode) {
-                            matches.addLeftOver(loser);
                             break;
                         }
                         //Or else Loser go back to UnMatched Queue & Waiting for it's Matching Procedure

--- a/src/main/java/com/example/SS2_Backend/ss/smt/implement/OTMProblem.java
+++ b/src/main/java/com/example/SS2_Backend/ss/smt/implement/OTMProblem.java
@@ -148,7 +148,6 @@ public class OTMProblem implements MatchingProblem {
             }
 
             PreferenceList consumerPreference = getPreferenceLists().get(consumer);
-            boolean matched = false;
 
             // Try to match with each preferred provider
             for (int i = 0; i < consumerPreference.size(UNUSED_VAL); i++) {
@@ -163,7 +162,6 @@ public class OTMProblem implements MatchingProblem {
                 if (!matches.isFull(provider, matchingData.getCapacityOf(provider))) {
                     matches.addMatchBi(provider, consumer);
                     matchedNode.add(consumer);
-                    matched = true;
                     break;
                 } else {
                     // Provider is at capacity - check if current consumer is preferred over existing matches
@@ -183,29 +181,16 @@ public class OTMProblem implements MatchingProblem {
 
                         matches.addMatchBi(provider, consumer);
                         matchedNode.add(consumer);
-                        matched = true;
                         break;
                     } else if (preferenceLists.getLastChoiceOf(UNUSED_VAL, consumer) == provider) {
                         // If this was consumer's last choice and they weren't preferred, add to leftovers
-                        matches.addLeftOver(consumer);
                         break;
                     }
                 }
             }
-
-            if (!matched && !matches.getLeftOvers().contains(consumer)) {
-                matches.addLeftOver(consumer);
-            }
         }
 
         // Add any remaining unmatched providers to leftovers
-        while (!unmatchedProviders.isEmpty()) {
-            int provider = unmatchedProviders.poll();
-            if (matches.getSetOf(provider).isEmpty()) {
-                matches.addLeftOver(provider);
-            }
-        }
-
         return matches;
     }
 

--- a/src/main/java/com/example/SS2_Backend/ss/smt/implement/OTOProblem.java
+++ b/src/main/java/com/example/SS2_Backend/ss/smt/implement/OTOProblem.java
@@ -173,11 +173,6 @@ public class OTOProblem implements MatchingProblem {
                     }
 
                     if (foundMatch) break;
-
-                    // If reached end of preference list without finding match
-                    if (i == prefLen - 1) {
-                        matches.addLeftOver(a);
-                    }
                 }
             }
         }

--- a/src/main/java/com/example/SS2_Backend/ss/smt/implement/OTOProblem.java
+++ b/src/main/java/com/example/SS2_Backend/ss/smt/implement/OTOProblem.java
@@ -131,11 +131,9 @@ public class OTOProblem implements MatchingProblem {
         int[] order = ((Permutation) var).toArray();
         Queue<Integer> singleQueue = Arrays.stream(order).boxed().collect(Collectors.toCollection(LinkedList::new));
         Matches matches = new Matches(getProblemSize());
-        Set<Integer> matched = new HashSet<>();
 
         while (!singleQueue.isEmpty()) {
             int a = singleQueue.poll();
-            if (matched.contains(a)) continue;
 
             PreferenceList aPreference = getPreferenceLists().get(a);
             int prefLen = aPreference.size(0);
@@ -147,12 +145,9 @@ public class OTOProblem implements MatchingProblem {
                 // If already matched to each other, skip
                 if (matches.isMatched(a, b)) break;
 
-                if (!matched.contains(b)) {
+                if (!matches.isMatched(b)) {
                     // Case 1: b is unmatched
-                    matched.add(a);
-                    matched.add(b);
                     matches.addMatchBi(a, b);
-                    foundMatch = true;
                     break;
                 } else {
                     // Case 2: b is already matched
@@ -163,9 +158,7 @@ public class OTOProblem implements MatchingProblem {
                     for (int bPartner : bPartners) {
                         if (bLikeAMore(a, b, bPartner)) {
                             singleQueue.add(bPartner);
-                            matched.remove(bPartner);
                             matches.removeMatchBi(b, bPartner);
-                            matched.add(a);
                             matches.addMatchBi(a, b);
                             foundMatch = true;
                             break;


### PR DESCRIPTION
## Make leftOvers a derived attribute
Instead of manually managing the set of leftOvers within `stableMatching()`, calculate after solved

## Remove `matchedNodes` in `stableMatching()`
Checking if a node is matched can be done using `Matches.isMatched(int index)`, remove `matchedNodes` to eliminate duplication